### PR TITLE
WORKFLOW-1131: Migrate passport-saml@0.33 -> @node-saml/passport-saml@5 (clears remaining 6 vulns)

### DIFF
--- a/config-adfs.js
+++ b/config-adfs.js
@@ -1,15 +1,27 @@
 var config = {
     myapikey: {
         samlStrategy: {
-            path: '/myapikey/callback',
+            // v5: `path`/`protocol`/`host` were removed; an absolute `callbackUrl`
+            // is now REQUIRED. It must be the externally-reachable URL of this
+            // app's POST callback route (/samlauth/<appkey>/login/callback) and
+            // must match the ACS URL registered at the IdP.
+            callbackUrl: 'https://your-integrify-host/samlauth/myapikey/login/callback',
             entryPoint: 'https://integrifyadfs.integrify.com/adfs/ls',
             issuer: "integrify-saml-client",
-            protocol: "https://",
-            cert: "idp-adfs.crt",
+            // v5: `cert` was renamed to `idpCert`.
+            idpCert: "idp-adfs.crt",
+            // v5: `audience` is validated. Defaults to `issuer`; set explicitly to
+            // the SP entityID the IdP expects, or set to false to disable.
+            audience: "integrify-saml-client",
             acceptedClockSkewMs: -1,
             authnContext: 'http://schemas.microsoft.com/ws/2008/06/identity/authenticationmethod/password',
             identifierFormat: null,
             signatureAlgorithm: 'sha256',
+            // v5 secure defaults (both true). Flip to false ONLY if your IdP does
+            // not sign the assertion / response respectively — verify against the
+            // live IdP before changing.
+            wantAssertionsSigned: true,
+            wantAuthnResponseSigned: true,
             loggerType: "dev"
         },
         integrify: {

--- a/config-openid.js
+++ b/config-openid.js
@@ -1,12 +1,19 @@
 var config = {
     myapikey: {
         samlStrategy: {
-
-            "path": "/myapikey/samlcallback",
+            // v5: `path`/`protocol` removed; absolute `callbackUrl` now REQUIRED
+            // (must match the ACS URL registered at the IdP).
+            "callbackUrl": "https://your-integrify-host/samlauth/myapikey/login/callback",
             "entryPoint": "https://openidp.feide.no/simplesaml/saml2/idp/SSOService.php",
             "issuer": "IntegrifySAMLTest",
-            "protocol": "http://",
-            cert: "idp-openid.crt"
+            // v5: `cert` renamed to `idpCert`.
+            "idpCert": "idp-openid.crt",
+            // v5: `audience` validated; defaults to `issuer`. Set to false to disable.
+            "audience": "IntegrifySAMLTest",
+            // v5 secure defaults (both true). Flip to false only if the IdP does not
+            // sign the assertion / response — verify against the live IdP first.
+            "wantAssertionsSigned": true,
+            "wantAuthnResponseSigned": true
         },
         integrify: {
             "service_user" : "iApprove",

--- a/config.sample.js
+++ b/config.sample.js
@@ -4,13 +4,22 @@ var config = {
 
             entryPoint: 'http://localhost:8080/simplesaml/saml2/idp/SSOService.php',
             issuer: "integrify-saml-client",
-            protocol: "http://",
-            cert: "idp.crt",
-            privateCert: "integrify.pem",
+            // v5: `cert` renamed to `idpCert` (IdP signing cert); `privateCert`
+            // renamed to `privateKey` (our SP private key). `protocol`/`path`/`host`
+            // were removed — use the absolute `callbackUrl` below.
+            idpCert: "idp.crt",
+            privateKey: "integrify.pem",
+            // v5: `audience` is validated; defaults to `issuer`. Set explicitly to the
+            // SP entityID the IdP expects, or set to false to disable the check.
+            audience: "integrify-saml-client",
             acceptedClockSkewMs: -1,
             // authnContext: 'urn:oasis:names:tc:SAML:2.0:ac:classes:Password<',
             identifierFormat: "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
             signatureAlgorithm: 'sha256',
+            // v5 secure defaults (both true). Flip to false ONLY if your IdP does not
+            // sign the assertion / response — verify against the live IdP first.
+            wantAssertionsSigned: true,
+            wantAuthnResponseSigned: true,
             loggerType: "dev",
             callbackUrl: "http://localhost:3001/samlauth/integrifyinstance/login/callback",
             forceAuthn: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,17 +9,233 @@
       "version": "1.2.0",
       "license": "ISC",
       "dependencies": {
+        "@node-saml/passport-saml": "^5.0.1",
         "body-parser": "^1.18.3",
         "cookie-parser": "^1.3.5",
         "express": "^4.16.3",
         "jsonwebtoken": "^9.0.2",
         "morgan": "^1.9.1",
         "passport": "^0.7.0",
-        "passport-saml": "^0.33.0",
         "ramda": "^0.25.0"
       },
       "engines": {
         "node": ">=22 <23"
+      }
+    },
+    "node_modules/@node-saml/node-saml": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@node-saml/node-saml/-/node-saml-5.1.0.tgz",
+      "integrity": "sha512-t3cJnZ4aC7HhPZ6MGylGZULvUtBOZ6FzuUndaHGXjmIZHXnLfC/7L8a57O9Q9V7AxJGKAiRM5zu2wNm9EsvQpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.1.12",
+        "@types/qs": "^6.9.18",
+        "@types/xml-encryption": "^1.2.4",
+        "@types/xml2js": "^0.4.14",
+        "@xmldom/is-dom-node": "^1.0.1",
+        "@xmldom/xmldom": "^0.8.10",
+        "debug": "^4.4.0",
+        "xml-crypto": "^6.1.2",
+        "xml-encryption": "^3.1.0",
+        "xml2js": "^0.6.2",
+        "xmlbuilder": "^15.1.1",
+        "xpath": "^0.0.34"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@node-saml/passport-saml": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@node-saml/passport-saml/-/passport-saml-5.1.0.tgz",
+      "integrity": "sha512-pBm+iFjv9eihcgeJuSUs4c0AuX1QEFdHwP8w1iaWCfDzXdeWZxUBU5HT2bY2S4dvNutcy+A9hYsH7ZLBGtgwDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@node-saml/node-saml": "^5.1.0",
+        "@types/express": "^4.17.23",
+        "@types/passport": "^1.0.17",
+        "@types/passport-strategy": "^0.2.38",
+        "passport": "^0.7.0",
+        "passport-strategy": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "^1"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.8",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
+      "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@types/passport": {
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.17.tgz",
+      "integrity": "sha512-aciLyx+wDwT2t2/kJGJR2AEeBz0nJU4WuRX04Wu9Dqc5lSUtwu0WERPHYsLhF9PtseiAMPBGNUOtFjxZ56prsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
+    "node_modules/@types/passport-strategy": {
+      "version": "0.2.38",
+      "resolved": "https://registry.npmjs.org/@types/passport-strategy/-/passport-strategy-0.2.38.tgz",
+      "integrity": "sha512-GC6eMqqojOooq993Tmnmp7AUTbbQSgilyvpCYQjT+H6JfG/g6RGc7nXEniZlp0zyKJ0WUdOiZWLBZft9Yug1uA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/passport": "*"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
+      "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "<1"
+      }
+    },
+    "node_modules/@types/serve-static/node_modules/@types/send": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/xml-encryption": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/xml-encryption/-/xml-encryption-1.2.4.tgz",
+      "integrity": "sha512-I69K/WW1Dv7j6O3jh13z0X8sLWJRXbu5xnHDl9yHzUNDUBtUoBY058eb5s+x/WG6yZC1h8aKdI2EoyEPjyEh+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/xml2js": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.14.tgz",
+      "integrity": "sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@xmldom/is-dom-node": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@xmldom/is-dom-node/-/is-dom-node-1.0.1.tgz",
+      "integrity": "sha512-CJDxIgE5I0FH+ttq/Fxy6nRpxP70+e2O048EPe85J2use3XKdatVM7dDVvFNjQudd9B49NPoZ+8PG49zj4Er8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/accepts": {
@@ -39,21 +255,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-      "license": "MIT"
-    },
-    "node_modules/async": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.14"
-      }
-    },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
     "node_modules/basic-auth": {
@@ -98,14 +299,20 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
-    "node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "ms": "2.0.0"
       }
+    },
+    "node_modules/body-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
@@ -201,12 +408,20 @@
       "license": "MIT"
     },
     "node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
-        "ms": "2.0.0"
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/depd": {
@@ -256,21 +471,6 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
-    },
-    "node_modules/ejs": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
-      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "jake": "^10.8.5"
-      },
-      "bin": {
-        "ejs": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -372,14 +572,20 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/filelist": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
-      "integrity": "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==",
-      "license": "Apache-2.0",
+    "node_modules/express/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
       "dependencies": {
-        "minimatch": "^5.0.1"
+        "ms": "2.0.0"
       }
+    },
+    "node_modules/express/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/finalhandler": {
       "version": "1.3.2",
@@ -398,6 +604,21 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/finalhandler/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/finalhandler/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
@@ -546,29 +767,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/jake": {
-      "version": "10.9.4",
-      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
-      "integrity": "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "async": "^3.2.6",
-        "filelist": "^1.0.4",
-        "picocolors": "^1.1.1"
-      },
-      "bin": {
-        "jake": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/jake/node_modules/async": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-      "license": "MIT"
-    },
     "node_modules/jsonwebtoken": {
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
@@ -591,12 +789,6 @@
         "npm": ">=6"
       }
     },
-    "node_modules/jsonwebtoken/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
     "node_modules/jwa": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
@@ -617,12 +809,6 @@
         "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "license": "MIT"
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
@@ -735,18 +921,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/morgan": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.11.0.tgz",
@@ -767,10 +941,25 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/ms": {
+    "node_modules/morgan/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/morgan/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/negotiator": {
@@ -780,15 +969,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/node-forge": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
-      "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw==",
-      "license": "(BSD-3-Clause OR GPL-2.0)",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/object-inspect": {
@@ -851,25 +1031,6 @@
         "url": "https://github.com/sponsors/jaredhanson"
       }
     },
-    "node_modules/passport-saml": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/passport-saml/-/passport-saml-0.33.0.tgz",
-      "integrity": "sha512-NK4Q8uK5ue1Mma9wuD+OQN6OP6D217a02WPUFg9cgLLgXDQSfxYqD28sv9j4yBiZEkAWfYE1Bu8K17rsHNOKcg==",
-      "deprecated": "For versions >= 4, please use scopped package @node-saml/passport-saml",
-      "license": "MIT",
-      "dependencies": {
-        "passport-strategy": "*",
-        "q": "^1.5.0",
-        "xml-crypto": "^0.10.1",
-        "xml-encryption": "^0.11.0",
-        "xml2js": "0.4.x",
-        "xmlbuilder": "^9.0.4",
-        "xmldom": "0.1.x"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/passport-strategy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
@@ -889,12 +1050,6 @@
       "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
       "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
     },
-    "node_modules/picocolors": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "license": "ISC"
-    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -906,17 +1061,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/q": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
-      "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6.0",
-        "teleport": ">=0.2.0"
       }
     },
     "node_modules/qs": {
@@ -1035,10 +1179,19 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/send/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+    "node_modules/send/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/send/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
     "node_modules/serve-static": {
@@ -1165,6 +1318,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "license": "MIT"
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -1193,47 +1352,52 @@
       }
     },
     "node_modules/xml-crypto": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-0.10.1.tgz",
-      "integrity": "sha512-w64qUhByslUJ9D9nwfCyRUCXfVWA5WdzHevHT3BwAig2KOsDNYcuvE2soGUGUs0qp9cy+vGG6B/Ap8qCXPLN/g==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-6.1.2.tgz",
+      "integrity": "sha512-leBOVQdVi8FvPJrMYoum7Ici9qyxfE4kVi+AkpUoYCSXaQF4IlBm1cneTK9oAxR61LpYxTx7lNcsnBIeRpGW2w==",
       "license": "MIT",
       "dependencies": {
-        "xmldom": "=0.1.19",
-        "xpath.js": ">=0.0.3"
+        "@xmldom/is-dom-node": "^1.0.1",
+        "@xmldom/xmldom": "^0.8.10",
+        "xpath": "^0.0.33"
       },
       "engines": {
-        "node": ">=0.4.0"
+        "node": ">=16"
       }
     },
-    "node_modules/xml-crypto/node_modules/xmldom": {
-      "version": "0.1.19",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.19.tgz",
-      "integrity": "sha512-pDyxjQSFQgNHkU+yjvoF+GXVGJU7e9EnOg/KcGMDihBIKjTsOeDYaECwC/O9bsUWKY+Sd9izfE43JXC46EOHKA==",
-      "deprecated": "Deprecated due to CVE-2021-21366 resolved in 0.5.0",
+    "node_modules/xml-crypto/node_modules/xpath": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.33.tgz",
+      "integrity": "sha512-NNXnzrkDrAzalLhIUc01jO2mOzXGXh1JwPgkihcLLzw98c0WgYDmmjSh1Kl3wzaxSVWMuA+fe0WTWOBDWCBmNA==",
+      "license": "MIT",
       "engines": {
-        "node": ">=0.1"
+        "node": ">=0.6.0"
       }
     },
     "node_modules/xml-encryption": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/xml-encryption/-/xml-encryption-0.11.2.tgz",
-      "integrity": "sha512-jVvES7i5ovdO7N+NjgncA326xYKjhqeAnnvIgRnY7ROLCfFqEDLwP0Sxp/30SHG0AXQV1048T5yinOFyvwGFzg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/xml-encryption/-/xml-encryption-3.1.0.tgz",
+      "integrity": "sha512-PV7qnYpoAMXbf1kvQkqMScLeQpjCMixddAKq9PtqVrho8HnYbBOWNfG0kA4R7zxQDo7w9kiYAyzS/ullAyO55Q==",
       "license": "MIT",
       "dependencies": {
-        "async": "^2.1.5",
-        "ejs": "^2.5.6",
-        "node-forge": "^0.7.0",
-        "xmldom": "~0.1.15",
-        "xpath": "0.0.27"
-      },
+        "@xmldom/xmldom": "^0.8.5",
+        "escape-html": "^1.0.3",
+        "xpath": "0.0.32"
+      }
+    },
+    "node_modules/xml-encryption/node_modules/xpath": {
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.32.tgz",
+      "integrity": "sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw==",
+      "license": "MIT",
       "engines": {
-        "node": ">=0.10"
+        "node": ">=0.6.0"
       }
     },
     "node_modules/xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
       "license": "MIT",
       "dependencies": {
         "sax": ">=0.6.0",
@@ -1253,40 +1417,21 @@
       }
     },
     "node_modules/xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha512-7YXTQc3P2l9+0rjaUbLwMKRhtmwg1M1eDf6nag7urC7pIPYLD9W/jmzQ4ptRSUbodw5S0jfoGTflLemQibSpeQ==",
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
       "license": "MIT",
       "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/xmldom": {
-      "version": "0.1.31",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
-      "integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==",
-      "deprecated": "Deprecated due to CVE-2021-21366 resolved in 0.5.0",
-      "license": "(LGPL-2.0 or MIT)",
-      "engines": {
-        "node": ">=0.1"
+        "node": ">=8.0"
       }
     },
     "node_modules/xpath": {
-      "version": "0.0.27",
-      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.27.tgz",
-      "integrity": "sha512-fg03WRxtkCV6ohClePNAECYsmpKKTv5L8y/X3Dn1hQrec3POx2jHZ/0P2qQ6HvsrU1BmeqXcof3NGGueG6LxwQ==",
+      "version": "0.0.34",
+      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.34.tgz",
+      "integrity": "sha512-FxF6+rkr1rNSQrhUNYrAFJpRXNzlDoMxeXN5qI84939ylEv3qqPFKa85Oxr6tDaJKqwW6KKyo2v26TSv3k6LeA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.6.0"
-      }
-    },
-    "node_modules/xpath.js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/xpath.js/-/xpath.js-1.1.0.tgz",
-      "integrity": "sha512-jg+qkfS4K8E7965sqaUl8mRngXiKb3WZGfONgE18pr03FUQiuSV6G+Ej4tS55B+rIQSFEIw3phdVAQ4pPqNWfQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -17,12 +17,11 @@
     "express": "^4.16.3",
     "jsonwebtoken": "^9.0.2",
     "morgan": "^1.9.1",
+    "@node-saml/passport-saml": "^5.0.1",
     "passport": "^0.7.0",
-    "passport-saml": "^0.33.0",
     "ramda": "^0.25.0"
   },
   "overrides": {
-    "qs": ">=6.14.1",
-    "ejs": "^3.1.10"
+    "qs": ">=6.14.1"
   }
 }

--- a/route.js
+++ b/route.js
@@ -41,7 +41,9 @@ app.use(samls.passport.initialize());
 app.get('/:appkey/metadata', function (req, res) {
 
     var strategy = samls.passport._strategies['saml-' + req.params.appkey];
-    var metaData = strategy.generateServiceProviderMetadata()
+    // v5 signature: generateServiceProviderMetadata(decryptionCert, signingCert).
+    // We embed no SP certs in the metadata (same as before), so pass null/null.
+    var metaData = strategy.generateServiceProviderMetadata(null, null)
 
     res.type('text/xml')
     res.send(metaData);

--- a/samls.js
+++ b/samls.js
@@ -1,7 +1,7 @@
 /**
  * Created by trusky on 9/21/15.
  */
-var SamlStrategy = require('passport-saml').Strategy
+var SamlStrategy = require('@node-saml/passport-saml').Strategy
 var fs = require ("fs")
 var path = require("path")
 var R  = require("ramda")
@@ -16,36 +16,36 @@ var Samls = function samls() {
 
         var loadStrategy = function (appkey) {
             var thisConfig = config[appkey];
-            if (thisConfig.samlStrategy.cert) {
+            // v5: `cert` was renamed to `idpCert` (the IdP's signing certificate).
+            if (thisConfig.samlStrategy.idpCert) {
                 try {
-                    thisConfig.samlStrategy.cert = fs.readFileSync(path.join(__dirname, thisConfig.samlStrategy.cert), 'utf-8')
-
-
-
+                    thisConfig.samlStrategy.idpCert = fs.readFileSync(path.join(__dirname, thisConfig.samlStrategy.idpCert), 'utf-8')
                 }
                 catch (e) {
                     console.error(e)
                 }
 
             }
-            if (thisConfig.samlStrategy.privateCert) {
+            // v5: `privateCert` was renamed to `privateKey` (our SP private key for signing requests).
+            if (thisConfig.samlStrategy.privateKey) {
                 try {
-                    thisConfig.samlStrategy.privateCert = fs.readFileSync(path.join(__dirname, thisConfig.samlStrategy.privateCert), 'utf-8')
-
-
-
+                    thisConfig.samlStrategy.privateKey = fs.readFileSync(path.join(__dirname, thisConfig.samlStrategy.privateKey), 'utf-8')
                 }
                 catch (e) {
                     console.error(e)
                 }
 
             }
+            // v5: the Strategy constructor takes TWO verify callbacks — one for
+            // sign-on and a (now required) one for logout. Both simply pass the
+            // profile through, preserving the prior single-callback behavior.
             var samlStrat = new SamlStrategy(
                 thisConfig.samlStrategy,
                 function (profile, done) {
-
                     return done(null, profile);
-
+                },
+                function (profile, done) {
+                    return done(null, profile);
                 });
             samlStrat.name = 'saml-' + appkey;
 


### PR DESCRIPTION
## Summary
Replaces the abandoned `passport-saml@0.33.0` with the maintained `@node-saml/passport-saml@5`, clearing the **last 6 advisories** in this repo (the `node-forge` / `xml-crypto` / `xml2js` / `xmldom` XML cluster).

`npm audit`: **6 → 0**. With this + the prior inline-token PR, `integrify-saml-auth` is at **0 vulnerabilities**.

> ⚠️ **Code-complete but NOT tested against a live IdP.** This is a ~6-major-version jump with no official migration guide. The mechanical/API changes below are done and smoke-tested; the *runtime validation* defaults (Tier 2) can only be confirmed against the real ADFS/IdP. **Do not merge to a release without a full login + logout round-trip against each customer IdP.**

## Changes made

### Tier 1 — load-blocking config renames
- `cert` → **`idpCert`** (config-adfs, config-openid, config.sample + the `readFileSync` in `samls.js`)
- `privateCert` → **`privateKey`** (config.sample + `samls.js`)
- Removed `path` / `protocol` — v5 requires an absolute **`callbackUrl`** (added placeholder full URLs to the ADFS/OpenIDP configs, which previously only had relative `path`)

### Tier 3 — API surface
- `samls.js`: require `@node-saml/passport-saml`; pass the now-**required second (logout) verify callback** alongside the sign-on one
- `route.js`: `generateServiceProviderMetadata(null, null)` for the v5 two-arg signature
- `package.json`: dep swap; dropped the now-dead `ejs` override (old xml-encryption chain is gone); kept `qs` (express)

### Tier 2 — security defaults (THE THING TO TEST)
Set **explicitly** with comments rather than relying on hidden defaults:
- `wantAssertionsSigned: true`
- `wantAuthnResponseSigned: true`
- `audience: <issuer>` (now validated in v5)

These flip ON behavior that 0.33 left optional. If a customer's IdP doesn't sign the assertion **and** the response, or issues a different audience/entityID, **logins will be rejected at runtime**. The comments tell the operator exactly which knob to turn, but the correct values depend on each IdP's config.

## Verification done
- `npm audit` → 0 vulnerabilities
- `node --check` passes on all touched files
- v5 `Strategy` constructs with the migrated config shape (callbackUrl + idpCert + audience + two verify callbacks) and `generateServiceProviderMetadata(null, null)` produces valid SP metadata (EntityDescriptor present)

## Test plan before release
1. Point a config at a real ADFS/IdP, set the absolute `callbackUrl` to match the ACS URL registered at the IdP.
2. Full SP-initiated login round-trip → confirm assertion accepted and Integrify token issued.
3. `/<appkey>/metadata` returns valid XML the IdP accepts.
4. Logout round-trip (`/<appkey>/logout`).
5. If login fails on signature/audience, adjust `wantAssertionsSigned` / `wantAuthnResponseSigned` / `audience` per the live IdP and document the required values.

## Refs
- [node-saml CHANGELOG](https://github.com/node-saml/node-saml/blob/master/CHANGELOG.md) — cert→idpCert, audience required, signed-by-default
- [passport-saml CHANGELOG](https://github.com/node-saml/passport-saml/blob/master/CHANGELOG.md)
- [Issue #909](https://github.com/node-saml/passport-saml/issues/909) — path removed / callbackUrl required / no migration guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)